### PR TITLE
Matching user and group IDs of petalinux docker user to machine user 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,9 +105,14 @@ RUN wget https://www.python.org/ftp/python/3.11.4/Python-3.11.4.tgz \
   && cd .. && rm Python-3.11.*.tgz && rm -rf Python-3.11.*/
 
 # make a petalinux user
-RUN adduser --disabled-password --gecos '' petalinux && \
+ARG UID
+ARG GID
+
+RUN groupadd --gid ${GID} petalinux_docker
+
+RUN adduser --uid ${UID} --gid ${GID} --disabled-password --gecos '' petalinux && \
   usermod -aG sudo petalinux && \
-  echo "petalinux ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+  echo "petalinux ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers 
 
 # Install the repo tool to handle git submodules (meta layers) comfortably.
 ADD https://storage.googleapis.com/git-repo-downloads/repo /usr/local/bin/

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -70,7 +70,7 @@ if ! ps -fC python3 | grep "http.server" > /dev/null ; then
 fi
 
 echo "Creating Docker image docker_petalinux2:$XILVER..."
-time docker build --build-arg PETA_VERSION="${XILVER}" --build-arg PETA_RUN_FILE="${PLNX}" "${INSTALL_VIVADO[@]}" -t docker_petalinux2:"${XILVER}" .
+time docker build --build-arg USERNAME=petalinux --build-arg UID=$(id -u) --build-arg GID=$(id -g) --build-arg PETA_VERSION="${XILVER}" --build-arg PETA_RUN_FILE="${PLNX}" "${INSTALL_VIVADO[@]}" -t docker_petalinux2:"${XILVER}" .
 if [ -f "y2k22_patch-1.2.zip" ] ; then
     rm "y2k22_patch-1.2.zip"
 fi


### PR DESCRIPTION
In some cases, if the user is not a local user but a non-local user that gets a UID and GID from a network, permission denial can occur and no files/folder can be created or modified. This fix shall always align the UID and GID of the petalinux docker user to the UID and GID of the user that runs the container