### PR TITLE
Use host UID/GID to avoid bind mount permission errors

### DIFF
--- a/etc/petalin2.sh
+++ b/etc/petalin2.sh
@@ -36,7 +36,7 @@ fi
 IFS=" " read -r -a OVERRIDE_ENTRYPOINT <<< "$OVERRIDE_ENTRYPOINT_AUX"
 IFS=" " read -r -a SET_DOCKER_COMMAND <<< "$SET_DOCKER_COMMAND_AUX"
 
-docker run -ti "${SET_X_SERVER[@]}" "${SET_MIRROR_PATH[@]}" -v "$PWD":"$PWD":z -v "$PWD/tftpboot":/tftpboot:z -w "$PWD" --rm -u petalinux "${OVERRIDE_ENTRYPOINT[@]}" docker_petalinux2:"${latest}" "${SET_DOCKER_COMMAND[@]}"
+docker run -ti "${SET_X_SERVER[@]}" "${SET_MIRROR_PATH[@]}" -v "$PWD":"$PWD":z -v "$PWD/tftpboot":/tftpboot:z -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -w "$PWD" --rm -u "$(id -u):$(id -g)" "${OVERRIDE_ENTRYPOINT[@]}" docker_petalinux2:"${latest}" "${SET_DOCKER_COMMAND[@]}"
 
 if [ "$OVERRIDE_ENTRYPOINT_AUX" ]
     then


### PR DESCRIPTION
@carlesfernandez Bind-mounted project directories were not writable when running the
container as the internal 'petalinux' user. This PR allows to run the container using the host UID/GID to ensure correct permissions on mounted volumes, especially on SELinux-enabled systems.